### PR TITLE
workfiles2 변경

### DIFF
--- a/env/includes/settings/tk-houdini.yml
+++ b/env/includes/settings/tk-houdini.yml
@@ -72,7 +72,7 @@ settings.tk-houdini.project:
       location: "@apps.tk-multi-about.location"
     tk-multi-screeningroom: "@settings.tk-multi-screeningroom.rv"
     tk-multi-shotgunpanel: "@settings.tk-multi-shotgunpanel"
-    tk-multi-workfiles2: "@settings.tk-multi-workfiles2"
+    tk-multi-workfiles2: "@settings.tk-multi-workfiles2.houdini.project"
     tk-multi-loader2: "@settings.tk-multi-loader2.houdini"
     tk-multi-library: "@settings.tk-multi-library.houdini"
     tk-multi-timelog: "@settings.tk-multi-timelog"

--- a/env/includes/settings/tk-maya.yml
+++ b/env/includes/settings/tk-maya.yml
@@ -73,7 +73,7 @@ settings.tk-maya.project:
       location: "@apps.tk-multi-about.location"
     tk-multi-screeningroom: "@settings.tk-multi-screeningroom.rv"
     tk-multi-shotgunpanel: "@settings.tk-multi-shotgunpanel"
-    tk-multi-workfiles2: "@settings.tk-multi-workfiles2.launch_at_startup"
+    tk-multi-workfiles2: "@settings.tk-multi-workfiles2.maya.project"
     tk-multi-loader2: "@settings.tk-multi-loader2.maya"
     tk-multi-library: "@settings.tk-multi-library.maya"
     tk-multi-timelog: "@settings.tk-multi-timelog"

--- a/env/includes/settings/tk-multi-workfiles2.yml
+++ b/env/includes/settings/tk-multi-workfiles2.yml
@@ -153,6 +153,10 @@ settings.tk-multi-workfiles2.hiero:
 # ---- Houdini
 
 # asset_step
+settings.tk-multi-workfiles2.houdini.project:
+  hook_scene_operation: "{config}/tk-multi-workfiles2/scene_operation_tk-houdini.py"
+  location: "@apps.tk-multi-workfiles2.location"
+
 settings.tk-multi-workfiles2.houdini.asset_step:
   hook_scene_operation: "{config}/tk-multi-workfiles2/scene_operation_tk-houdini.py"
   template_publish: houdini_asset_publish

--- a/env/includes/settings/tk-multi-workfiles2.yml
+++ b/env/includes/settings/tk-multi-workfiles2.yml
@@ -344,6 +344,9 @@ settings.tk-multi-workfiles2.nuke.shot_step:
 ################################################################################
 
 # ---- photoshop
+settings.tk-multi-workfiles2.photoshop.project:
+  hook_scene_operation: "{config}/tk-multi-workfiles2/scene_operation_tk-nuke.py"
+  location: "@apps.tk-multi-workfiles2.location"
 
 # asset_step
 settings.tk-multi-workfiles2.photoshop.asset_step:

--- a/env/includes/settings/tk-multi-workfiles2.yml
+++ b/env/includes/settings/tk-multi-workfiles2.yml
@@ -154,6 +154,7 @@ settings.tk-multi-workfiles2.hiero:
 
 # asset_step
 settings.tk-multi-workfiles2.houdini.asset_step:
+  hook_scene_operation: "{config}/tk-multi-workfiles2/scene_operation_tk-houdini.py"
   template_publish: houdini_asset_publish
   template_publish_area: asset_publish_area_houdini
   template_work: houdini_asset_work
@@ -181,6 +182,7 @@ settings.tk-multi-workfiles2.houdini.asset_step:
 
 # shot_step
 settings.tk-multi-workfiles2.houdini.shot_step:
+  hook_scene_operation: "{config}/tk-multi-workfiles2/scene_operation_tk-houdini.py"
   template_publish: houdini_shot_publish
   template_publish_area: shot_publish_area_houdini
   template_work: houdini_shot_work
@@ -210,8 +212,13 @@ settings.tk-multi-workfiles2.houdini.shot_step:
 
 # ---- Maya
 
+settings.tk-multi-workfiles2.maya.project:
+  hook_scene_operation: "{config}/tk-multi-workfiles2/scene_operation_tk-maya.py"
+  location: "@apps.tk-multi-workfiles2.location"
+
 # asset_step
 settings.tk-multi-workfiles2.maya.asset_step:
+  hook_scene_operation: "{config}/tk-multi-workfiles2/scene_operation_tk-maya.py"
   template_publish: maya_asset_publish
   template_publish_area: asset_publish_area_maya
   template_work: maya_asset_work
@@ -239,6 +246,7 @@ settings.tk-multi-workfiles2.maya.asset_step:
 
 # shot_step
 settings.tk-multi-workfiles2.maya.shot_step:
+  hook_scene_operation: "{config}/tk-multi-workfiles2/scene_operation_tk-maya.py"
   template_publish: maya_shot_publish
   template_publish_area: shot_publish_area_maya
   template_work: maya_shot_work
@@ -268,8 +276,14 @@ settings.tk-multi-workfiles2.maya.shot_step:
 
 # ---- nuke
 
+# project
+settings.tk-multi-workfiles2.nuke.project:
+  hook_scene_operation: "{config}/tk-multi-workfiles2/scene_operation_tk-nuke.py"
+  location: "@apps.tk-multi-workfiles2.location"
+
 # asset_step
 settings.tk-multi-workfiles2.nuke.asset_step:
+  hook_scene_operation: "{config}/tk-multi-workfiles2/scene_operation_tk-nuke.py"
   template_publish: nuke_asset_publish
   template_publish_area: asset_publish_area_nuke
   template_work: nuke_asset_work
@@ -297,6 +311,7 @@ settings.tk-multi-workfiles2.nuke.asset_step:
 
 # shot_step
 settings.tk-multi-workfiles2.nuke.shot_step:
+  hook_scene_operation: "{config}/tk-multi-workfiles2/scene_operation_tk-nuke.py"
   template_publish: nuke_shot_publish
   template_publish_area: shot_publish_area_nuke
   template_work: nuke_shot_work
@@ -328,6 +343,7 @@ settings.tk-multi-workfiles2.nuke.shot_step:
 
 # asset_step
 settings.tk-multi-workfiles2.photoshop.asset_step:
+  hook_scene_operation: "{config}/tk-multi-workfiles2/scene_operation_tk-photoshop.py"
   template_publish: photoshop_asset_publish
   template_publish_area: asset_publish_area_photoshop
   template_work: photoshop_asset_work
@@ -355,6 +371,7 @@ settings.tk-multi-workfiles2.photoshop.asset_step:
 
 # shot_step
 settings.tk-multi-workfiles2.photoshop.shot_step:
+  hook_scene_operation: "{config}/tk-multi-workfiles2/scene_operation_tk-photoshop.py"
   template_publish: photoshop_shot_publish
   template_publish_area: shot_publish_area_photoshop
   template_work: photoshop_shot_work
@@ -441,6 +458,7 @@ settings.tk-multi-workfiles2.motionbuilder.shot_step:
 # ---- Katana
 
 settings.tk-multi-workfiles2.katana.project:
+  hook_scene_operation: "{config}/tk-multi-workfiles2/scene_operation_tk-katana.py"
   allow_task_creation: true
   create_new_task_hook: "{self}/create_new_task.py"
   custom_actions_hook: "{self}/custom_actions.py"
@@ -459,7 +477,7 @@ settings.tk-multi-workfiles2.katana.project:
   hook_copy_file: "{self}/copy_file.py"
   hook_filter_publishes: default
   hook_filter_work_files: default
-  hook_scene_operation: "{engine}/scene_operation_tk-katana.py"
+  # hook_scene_operation: "{engine}/scene_operation_tk-katana.py"
   launch_at_startup: false
   my_tasks_extra_display_fields: []
   saveas_default_name: scene
@@ -474,7 +492,8 @@ settings.tk-multi-workfiles2.katana.project:
 
 # asset_step
 settings.tk-multi-workfiles2.katana.asset_step:
-  hook_scene_operation: "{engine}/tk-multi-workfiles2/scene_operation_tk-katana.py"
+  # hook_scene_operation: "{engine}/tk-multi-workfiles2/scene_operation_tk-katana.py"
+  hook_scene_operation: "{config}/tk-multi-workfiles2/scene_operation_tk-katana.py"
   template_publish: katana_asset_publish
   template_publish_area: asset_publish_area_katana
   template_work: katana_asset_work
@@ -483,7 +502,8 @@ settings.tk-multi-workfiles2.katana.asset_step:
 
 # shot_step
 settings.tk-multi-workfiles2.katana.shot_step:
-  hook_scene_operation: "{engine}/tk-multi-workfiles2/scene_operation_tk-katana.py"
+  # hook_scene_operation: "{engine}/tk-multi-workfiles2/scene_operation_tk-katana.py"
+  hook_scene_operation: "{config}/tk-multi-workfiles2/scene_operation_tk-katana.py"
   template_publish: katana_shot_publish
   template_publish_area: shot_publish_area_katana
   template_work: katana_shot_work
@@ -495,6 +515,7 @@ settings.tk-multi-workfiles2.katana.shot_step:
 # ---- 3DE
 
 settings.tk-multi-workfiles2.3de4.project:
+  hook_scene_operation: "{config}/tk-multi-workfiles2/scene_operation_tk-3de4.py"
   allow_task_creation: true
   create_new_task_hook: "{self}/create_new_task.py"
   custom_actions_hook: "{self}/custom_actions.py"
@@ -508,7 +529,7 @@ settings.tk-multi-workfiles2.3de4.project:
   hook_copy_file: "{self}/copy_file.py"
   hook_filter_publishes: default
   hook_filter_work_files: default
-  hook_scene_operation: "{engine}/tk-multi-workfiles2/scene_operation_tk-3de4.py"
+  # hook_scene_operation: "{engine}/tk-multi-workfiles2/scene_operation_tk-3de4.py"
   launch_at_startup: false
   my_tasks_extra_display_fields: []
   saveas_default_name: scene
@@ -524,7 +545,8 @@ settings.tk-multi-workfiles2.3de4.project:
 
 # shot_step
 settings.tk-multi-workfiles2.3de4.shot_step:
-  hook_scene_operation: "{engine}/tk-multi-workfiles2/scene_operation_tk-3de4.py"
+  # hook_scene_operation: "{engine}/tk-multi-workfiles2/scene_operation_tk-3de4.py"
+  hook_scene_operation: "{config}/tk-multi-workfiles2/scene_operation_tk-3de4.py"
   template_publish: 3de4_shot_publish
   template_publish_area: shot_publish_area_3de4
   template_work: 3de4_shot_work
@@ -537,6 +559,7 @@ settings.tk-multi-workfiles2.3de4.shot_step:
 # -- clarisse
 
 settings.tk-multi-workfiles2.clarisse.project:
+  hook_scene_operation: "{config}/tk-multi-workfiles2/scene_operation_tk-clarisse.py"
   allow_task_creation: true
   create_new_task_hook: "{self}/create_new_task.py"
   custom_actions_hook: "{self}/custom_actions.py"
@@ -555,7 +578,7 @@ settings.tk-multi-workfiles2.clarisse.project:
   hook_copy_file: "{self}/copy_file.py"
   hook_filter_publishes: default
   hook_filter_work_files: default
-  hook_scene_operation: "{engine}/tk-multi-workfiles2/scene_operation_tk-clarisse.py"
+  # hook_scene_operation: "{engine}/tk-multi-workfiles2/scene_operation_tk-clarisse.py"
   launch_at_startup: false
   my_tasks_extra_display_fields: []
   saveas_default_name: scene
@@ -570,7 +593,8 @@ settings.tk-multi-workfiles2.clarisse.project:
 
 # asset_step
 settings.tk-multi-workfiles2.clarisse.asset_step:
-  hook_scene_operation: "{engine}/tk-multi-workfiles2/scene_operation_tk-clarisse.py"
+  # hook_scene_operation: "{engine}/tk-multi-workfiles2/scene_operation_tk-clarisse.py"
+  hook_scene_operation: "{config}/tk-multi-workfiles2/scene_operation_tk-clarisse.py"
   template_publish: clarisse_asset_publish
   template_publish_area: asset_publish_area_clarisse
   template_work: clarisse_asset_work
@@ -580,7 +604,8 @@ settings.tk-multi-workfiles2.clarisse.asset_step:
 
 # shot_step
 settings.tk-multi-workfiles2.clarisse.shot_step:
-  hook_scene_operation: "{engine}/tk-multi-workfiles2/scene_operation_tk-clarisse.py"
+  # hook_scene_operation: "{engine}/tk-multi-workfiles2/scene_operation_tk-clarisse.py"
+  hook_scene_operation: "{config}/tk-multi-workfiles2/scene_operation_tk-clarisse.py"
   template_publish: clarisse_shot_publish
   template_publish_area: shot_publish_area_clarisse
   template_work: clarisse_shot_work
@@ -589,7 +614,8 @@ settings.tk-multi-workfiles2.clarisse.shot_step:
 
 # sequence_step
 settings.tk-multi-workfiles2.clarisse.sequence_step:
-  hook_scene_operation: "{engine}/tk-multi-workfiles2/scene_operation_tk-clarisse.py"
+  # hook_scene_operation: "{engine}/tk-multi-workfiles2/scene_operation_tk-clarisse.py"
+  hook_scene_operation: "{config}/tk-multi-workfiles2/scene_operation_tk-clarisse.py"
   template_publish: clarisse_sequence_publish
   template_publish_area: sequence_publish_area_clarisse
   template_work: clarisse_sequence_work

--- a/env/includes/settings/tk-nuke.yml
+++ b/env/includes/settings/tk-nuke.yml
@@ -118,7 +118,7 @@ settings.tk-nuke.project:
     tk-multi-loader2: '@settings.tk-multi-loader2.nuke'
     tk-multi-screeningroom: '@settings.tk-multi-screeningroom.rv'
     tk-multi-shotgunpanel: '@settings.tk-multi-shotgunpanel'
-    tk-multi-workfiles2: '@settings.tk-multi-workfiles2'
+    tk-multi-workfiles2: '@settings.tk-multi-workfiles2.nuke.project'
     tk-multi-output: '@settings.tk-multi-output.nuke'
     tk-multi-timelog: "@settings.tk-multi-timelog"
   menu_favourites:

--- a/env/includes/ww_app_locations.yml
+++ b/env/includes/ww_app_locations.yml
@@ -34,8 +34,7 @@ apps.tk-maya-makemov.location:
 apps.tk-multi-output.location:
   name: tk-multi-output
   type: dev
-#  linux_path: /westworld/inhouse/tool/shotgun/application/tk-multi-output
-  linux_path: /storenext/user/pipeline/kyoungmin/work/toolkit/tk-multi-output
+  linux_path: /westworld/inhouse/tool/shotgun/application/tk-multi-output
   windows_path: \\10.0.40.42\inhouse\tool\shotgun\application\tk-multi-output
 
 
@@ -55,16 +54,14 @@ apps.tk-multi-txmake.location:
 apps.tk-multi-workfiles2.location:
   name: tk-multi-workfiles2
   type: dev
-  linux_path: /storenext/user/pipeline/kyoungmin/work/toolkit/tk-multi-workfiles2
-#  linux_path: /westworld/inhouse/tool/shotgun/application/tk-multi-workfiles2
+  linux_path: /westworld/inhouse/tool/shotgun/application/tk-multi-workfiles2
   windows_path: \\10.0.40.42\inhouse\tool\shotgun\application\tk-multi-workfiles2
 
 #tk-multi-version
 apps.tk-multi-version.location:
   name: tk-multi-version
   type: dev
-#  linux_path: /westworld/inhouse/tool/shotgun/application/tk-multi-version
-  linux_path: /storenext/user/pipeline/kyoungmin/work/toolkit/tk-multi-version
+  linux_path: /westworld/inhouse/tool/shotgun/application/tk-multi-version
   windows_path: \\10.0.40.42\inhouse\tool\shotgun\application\tk-multi-version
 
 

--- a/env/includes/ww_app_locations.yml
+++ b/env/includes/ww_app_locations.yml
@@ -34,7 +34,8 @@ apps.tk-maya-makemov.location:
 apps.tk-multi-output.location:
   name: tk-multi-output
   type: dev
-  linux_path: /westworld/inhouse/tool/shotgun/application/tk-multi-output
+#  linux_path: /westworld/inhouse/tool/shotgun/application/tk-multi-output
+  linux_path: /storenext/user/pipeline/kyoungmin/work/toolkit/tk-multi-output
   windows_path: \\10.0.40.42\inhouse\tool\shotgun\application\tk-multi-output
 
 
@@ -54,14 +55,16 @@ apps.tk-multi-txmake.location:
 apps.tk-multi-workfiles2.location:
   name: tk-multi-workfiles2
   type: dev
-  linux_path: /westworld/inhouse/tool/shotgun/application/tk-multi-workfiles2
+  linux_path: /storenext/user/pipeline/kyoungmin/work/toolkit/tk-multi-workfiles2
+#  linux_path: /westworld/inhouse/tool/shotgun/application/tk-multi-workfiles2
   windows_path: \\10.0.40.42\inhouse\tool\shotgun\application\tk-multi-workfiles2
 
 #tk-multi-version
 apps.tk-multi-version.location:
   name: tk-multi-version
   type: dev
-  linux_path: /westworld/inhouse/tool/shotgun/application/tk-multi-version
+#  linux_path: /westworld/inhouse/tool/shotgun/application/tk-multi-version
+  linux_path: /storenext/user/pipeline/kyoungmin/work/toolkit/tk-multi-version
   windows_path: \\10.0.40.42\inhouse\tool\shotgun\application\tk-multi-version
 
 

--- a/hooks/tk-multi-workfiles2/connect_databases.py
+++ b/hooks/tk-multi-workfiles2/connect_databases.py
@@ -1,0 +1,98 @@
+# -*- coding: utf-8 -*-
+
+import os
+import sys
+# sys.path.append('/show/RND/shotgun_toolkit_skm/install/core/python')
+# import sgtk
+import subprocess
+
+# HookBaseClass = sgtk.get_hook_baseclass()
+
+# class Databases(HookBaseClass):
+class Databases():
+    def __init__(self):
+        # rez_path = self._get_rez_module()
+        # sys.path.append(rez_path)
+        # print('*'*100)
+        # print(rez_path)
+        # print(sys.path)
+        # print('*'*100)
+        # # sys.path.insert(0,'/westworld/inhouse/tool/rez-packages/rez/2.23.1/platform-linux/arch-x86_64/os-CentOS-7.5.1804')
+        # from rez import resolved_context
+        # packages = ["psycopg2"]
+        # context = resolved_context.ResolvedContext(packages)
+        # path = self.get_publish_path(sg_publish_data).replace(os.path.sep, "/")
+        # command = "psycopg2"
+        # command += path
+        # print('*'*100)
+        # print(context.execute_shell(command = command,
+        #                         stdin = False,
+        #                         block = False,
+        #                     ))
+        # # import nuke
+        # # nuke.alert(context)
+        # # print(context)
+        # print('*'*100)
+        # sys.path.append(context)
+        # print(sys.path)
+        if sys.version_info.major == 3 :
+            sys.path.append('/westworld/inhouse/tool/rez-packages/psycopg2/2.8.6/platform-linux/arch-x86_64/lib/python3.7/site-packages')
+        else:
+            sys.path.append('/westworld/inhouse/tool/rez-packages/psycopg2/2.8.6/platform-linux/arch-x86_64/lib/python2.7/site-packages')
+        import psycopg2
+
+        self.db = psycopg2.connect( host = '10.0.20.7', dbname = 'WorkFilesLogs', user = 'postgres', password = 'postgres', port = 5432 )
+        self.cursor = self.db.cursor()
+
+    def __del__( self ):
+        self.db.close()
+        self.cursor.close()
+
+    def execute( self, query, args = {} ):
+        self.cursor.execute( query, args )
+        row = self.cursor.fetchall()
+        return row
+
+    def commit( self ):
+        self.cursor.commit()
+
+    # def insertDB( self, schema, table, colum, data ):
+    #     sql = " INSERT INTO {schema}.{table}({colum}) VALUES ('{data}') ;".format( schema = schema, table = table, colum = colum, data = data )
+    #     try:
+    #         self.cursor.execute( sql )
+    #         self.db.commit()
+    #     except Exception as e :
+    #         print( "insert DB  ", e ) 
+
+    def insertDB( self, sql ):
+        print(sql)
+        try:
+            self.cursor.execute( sql )
+            self.db.commit()
+            print('input')
+        except Exception as e :
+            print( "insert DB error : ", e ) 
+    
+    def set_sql( self, user_name, tool, project_name, shot_name, file_name, operation ):
+        sql =   '''
+                    INSERT INTO logs ( user_name, tool, project, shot_name, file_name, operation, log_time )
+                    VALUES (\'{0}\', \'{1}\', \'{2}\', \'{3}\', \'{4}\', \'{5}\', current_timestamp);
+                '''.format( user_name, tool, project_name, shot_name, file_name, operation)
+        return sql
+
+    def _get_rez_module(self):
+        command = 'rez-env rez -- printenv REZ_REZ_ROOT'
+        module_path, stderr = subprocess.Popen(
+            command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True).communicate()
+        module_path = module_path.strip()
+        if not stderr and module_path:
+            return module_path
+        
+        return ""
+
+
+# print('start')
+# DB = Databases()
+# sql = DB.set_sql("신경민TD", "Nuke", "RND", "E114", "E114_114", 'OPEN' )
+# DB.insertDB(sql)
+# print('end')

--- a/hooks/tk-multi-workfiles2/connect_databases.py
+++ b/hooks/tk-multi-workfiles2/connect_databases.py
@@ -2,43 +2,22 @@
 
 import os
 import sys
-# sys.path.append('/show/RND/shotgun_toolkit_skm/install/core/python')
-# import sgtk
+import platform
 import subprocess
 
-# HookBaseClass = sgtk.get_hook_baseclass()
-
-# class Databases(HookBaseClass):
 class Databases():
     def __init__(self):
-        # rez_path = self._get_rez_module()
-        # sys.path.append(rez_path)
-        # print('*'*100)
-        # print(rez_path)
-        # print(sys.path)
-        # print('*'*100)
-        # # sys.path.insert(0,'/westworld/inhouse/tool/rez-packages/rez/2.23.1/platform-linux/arch-x86_64/os-CentOS-7.5.1804')
-        # from rez import resolved_context
-        # packages = ["psycopg2"]
-        # context = resolved_context.ResolvedContext(packages)
-        # path = self.get_publish_path(sg_publish_data).replace(os.path.sep, "/")
-        # command = "psycopg2"
-        # command += path
-        # print('*'*100)
-        # print(context.execute_shell(command = command,
-        #                         stdin = False,
-        #                         block = False,
-        #                     ))
-        # # import nuke
-        # # nuke.alert(context)
-        # # print(context)
-        # print('*'*100)
-        # sys.path.append(context)
-        # print(sys.path)
-        if sys.version_info.major == 3 :
-            sys.path.append('/westworld/inhouse/tool/rez-packages/psycopg2/2.8.6/platform-linux/arch-x86_64/lib/python3.7/site-packages')
-        else:
-            sys.path.append('/westworld/inhouse/tool/rez-packages/psycopg2/2.8.6/platform-linux/arch-x86_64/lib/python2.7/site-packages')
+        if platform.system() == 'Linux':
+            if sys.version_info.major == 3 :
+                sys.path.append('/westworld/inhouse/tool/rez-packages/psycopg2/2.8.6/platform-linux/arch-x86_64/lib/python3.7/site-packages')
+            else:
+                sys.path.append('/westworld/inhouse/tool/rez-packages/psycopg2/2.8.6/platform-linux/arch-x86_64/lib/python2.7/site-packages')
+        elif platform.system() == 'Windows':
+            if sys.version_info.major == 3 :
+                # if python3 is installed in window_inhouse then need to change
+                sys.path.append('/westworld/inhouse/window_inhouse/rez-packages/psycopg2/2.8.4/platform-windows/arch-AMD64/lib/python2.7/site-packages')
+            else:
+                sys.path.append('/westworld/inhouse/window_inhouse/rez-packages/psycopg2/2.8.4/platform-windows/arch-AMD64/lib/python2.7/site-packages')
         import psycopg2
 
         self.db = psycopg2.connect( host = '10.0.20.7', dbname = 'WorkFilesLogs', user = 'postgres', password = 'postgres', port = 5432 )
@@ -55,14 +34,6 @@ class Databases():
 
     def commit( self ):
         self.cursor.commit()
-
-    # def insertDB( self, schema, table, colum, data ):
-    #     sql = " INSERT INTO {schema}.{table}({colum}) VALUES ('{data}') ;".format( schema = schema, table = table, colum = colum, data = data )
-    #     try:
-    #         self.cursor.execute( sql )
-    #         self.db.commit()
-    #     except Exception as e :
-    #         print( "insert DB  ", e ) 
 
     def insertDB( self, sql ):
         print(sql)
@@ -89,10 +60,3 @@ class Databases():
             return module_path
         
         return ""
-
-
-# print('start')
-# DB = Databases()
-# sql = DB.set_sql("신경민TD", "Nuke", "RND", "E114", "E114_114", 'OPEN' )
-# DB.insertDB(sql)
-# print('end')

--- a/hooks/tk-multi-workfiles2/connect_databases.py
+++ b/hooks/tk-multi-workfiles2/connect_databases.py
@@ -15,9 +15,9 @@ class Databases():
         elif platform.system() == 'Windows':
             if sys.version_info.major == 3 :
                 # if python3 is installed in window_inhouse then need to change
-                sys.path.append('/westworld/inhouse/window_inhouse/rez-packages/psycopg2/2.8.4/platform-windows/arch-AMD64/lib/python2.7/site-packages')
+                sys.path.append('\\\\10.0.40.42\\inhouse\\window_inhouse\\rez-packages\\psycopg2\\2.8.4\\platform-windows\\arch-AMD64\\lib')
             else:
-                sys.path.append('/westworld/inhouse/window_inhouse/rez-packages/psycopg2/2.8.4/platform-windows/arch-AMD64/lib/python2.7/site-packages')
+                sys.path.append('\\\\10.0.40.42\\inhouse\\window_inhouse\\rez-packages\\psycopg2\\2.8.4\\platform-windows\\arch-AMD64\\lib')
         import psycopg2
 
         self.db = psycopg2.connect( host = '10.0.20.7', dbname = 'WorkFilesLogs', user = 'postgres', password = 'postgres', port = 5432 )
@@ -45,10 +45,16 @@ class Databases():
             print( "insert DB error : ", e ) 
     
     def set_sql( self, user_name, tool, project_name, shot_name, file_name, operation ):
+        if operation == 'NEW FILE' or operation == 'OPEN':
+            operation_type = 'START'
+        elif operation == 'SAVE' or operation == 'SAVE_AS':
+            operation_type = 'END'
+        else:
+            operation_type = None
         sql =   '''
-                    INSERT INTO logs ( user_name, tool, project, shot_name, file_name, operation, log_time )
-                    VALUES (\'{0}\', \'{1}\', \'{2}\', \'{3}\', \'{4}\', \'{5}\', current_timestamp);
-                '''.format( user_name, tool, project_name, shot_name, file_name, operation)
+                    INSERT INTO logs ( user_name, tool, project, shot_name, file_name, operation, operation_type, log_time )
+                    VALUES (\'{0}\', \'{1}\', \'{2}\', \'{3}\', \'{4}\', \'{5}\', \'{6}\', current_timestamp);
+                '''.format( user_name, tool, project_name, shot_name, file_name, operation, operation_type )
         return sql
 
     def _get_rez_module(self):

--- a/hooks/tk-multi-workfiles2/filter_publishes.py
+++ b/hooks/tk-multi-workfiles2/filter_publishes.py
@@ -1,0 +1,40 @@
+# Copyright (c) 2013 Shotgun Software Inc.
+# 
+# CONFIDENTIAL AND PROPRIETARY
+# 
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit 
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your 
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights 
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+import os
+
+import sgtk
+from sgtk import Hook
+
+class FilterPublishes(Hook):
+    """
+    Hook that can be used to filter the list of publishes returned from Shotgun for the current
+    Work area
+    """
+    
+    def execute(self, publishes, **kwargs):
+        """
+        Main hook entry point
+        
+        :param publishes:    List of dictionaries 
+                            A list of  dictionaries for the current work area within the app.  Each
+                            item in the list is a Dictionary of the form:
+                            
+                            {
+                                "sg_publish" : {Shotgun entity dictionary for a Published File entity}
+                            }
+                            
+        :returns:            The filtered list of dictionaries of the same form as the input 'publishes' 
+                            list
+        """
+        app = self.parent
+
+        # the default implementation just returns the unfiltered list:
+        return publishes

--- a/hooks/tk-multi-workfiles2/filter_work_files.py
+++ b/hooks/tk-multi-workfiles2/filter_work_files.py
@@ -1,0 +1,57 @@
+# Copyright (c) 2013 Shotgun Software Inc.
+# 
+# CONFIDENTIAL AND PROPRIETARY
+# 
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit 
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your 
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights 
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+import os
+
+import sgtk
+from sgtk import Hook
+
+class FilterWorkFiles(Hook):
+    """
+    Hook that can be used to filter the list of work files found by the app for the current
+    Work area
+    """
+    
+    def execute(self, work_files, **kwargs):
+        """
+        Main hook entry point
+        
+        :param work_files:   List of dictionaries 
+                            A list of  dictionaries for the current work area within the app.  Each
+                            item in the list is a Dictionary of the form:
+                            
+                            {
+                                "work_file" : {
+                                
+                                    Dictionary containing information about a single work file.  Valid entries in
+                                    this dicitionary are listed below but may not be populated when the hook is
+                                    executed!
+                                    
+                                    It is intended that custom versions of this hook should populate these fields
+                                    if needed before returning the filtered list  
+                                
+                                    version_number    - version of the work file
+                                    name              - name of the work file
+                                    task              - task the work file should be associated with
+                                    description       - description of the work file
+                                    thumbnail         - thumbnail that should be used for the work file
+                                    modified_at       - date & time the work file was last modified
+                                    modified_by       - Shotgun user entity dictionary for the person who
+                                                        last modified the work file
+                                }
+                            }
+                            
+        :returns:            The filtered list of dictionaries of the same form as the input 'work_files' 
+                            list
+        """
+        app = self.parent
+
+        # the default implementation just returns the unfiltered list:
+        return work_files

--- a/hooks/tk-multi-workfiles2/scene_operation_tk-3de4.py
+++ b/hooks/tk-multi-workfiles2/scene_operation_tk-3de4.py
@@ -1,0 +1,110 @@
+# By Sam Saxon sam.saxon@thefoundry.com
+# Copied from the equivalent Nuke file.
+
+import os
+import sys
+
+import sgtk
+from sgtk.platform.qt import QtGui
+import tde4
+
+HookClass = sgtk.get_hook_baseclass()
+
+sys.path.append(os.path.dirname(__file__))
+import connect_databases
+
+class SceneOperation(HookClass):
+    """
+    Hook called to perform an operation with the
+    current scene
+    """
+
+    def execute(self, operation, file_path, context, parent_action, file_version, read_only, **kwargs):
+        """
+        Main hook entry point
+
+        :param operation:       String
+                                Scene operation to perform
+
+        :param file_path:       String
+                                File path to use if the operation
+                                requires it (e.g. open)
+
+        :param context:         Context
+                                The context the file operation is being
+                                performed in.
+
+        :param parent_action:   This is the action that this scene operation is
+                                being executed for.  This can be one of:
+                                - open_file
+                                - new_file
+                                - save_file_as
+                                - version_up
+
+        :param file_version:    The version/revision of the file to be opened.  If this is 'None'
+                                then the latest version should be opened.
+
+        :param read_only:       Specifies if the file should be opened read-only or not
+
+        :returns:               Depends on operation:
+                                'current_path' - Return the current scene
+                                                file path as a String
+                                'reset'        - True if scene was reset to an empty
+                                                state, otherwise False
+                                all others     - None
+        """
+        
+        DB = connect_databases.Databases()
+        user_name    = context.user['name']
+        project_name = context.project['name']
+        shot_name    = context.entity['name']
+        tool         = '3de4'
+        if file_path:
+            file_path = file_path.replace("/", os.path.sep)
+            file_name = os.path.basename(file_path)
+        else :
+            file_name    = shot_name
+
+        if operation == "current_path":
+            # return the current scene path
+            return file_path
+
+        elif operation == "open":
+            tde4.loadProject(file_path)
+            sql = DB.set_sql( user_name, tool, project_name, shot_name, file_name, 'OPEN' )
+            DB.insertDB(sql)
+
+        elif operation == "save":
+            if not os.path.exists(os.path.dirname(file_path)):
+                os.makedirs(os.path.dirname(file_path))
+            tde4.saveProject(file_path)
+            sql = DB.set_sql( user_name, tool, project_name, shot_name, file_name, 'SAVE' )
+            DB.insertDB(sql)
+
+        elif operation == "save_as":
+            if not os.path.exists(os.path.dirname(file_path)):
+                os.makedirs(os.path.dirname(file_path))
+            tde4.saveProject(file_path)
+            sql = DB.set_sql( user_name, tool, project_name, shot_name, file_name, 'SAVE AS' )
+            DB.insertDB(sql)
+
+        elif operation == "prepare_new":
+            sql = DB.set_sql( user_name, tool, project_name, shot_name, file_name, 'NEW FILE' )
+            DB.insertDB(sql)
+
+
+        elif operation == "reset":
+            
+            if not tde4.isProjectUpToDate():
+                res = QtGui.QMessageBox.question(None,
+                                                "Save your scene?",
+                                                "Your scene has unsaved changes. Save before proceeding?",
+                                                QtGui.QMessageBox.Yes|QtGui.QMessageBox.No|QtGui.QMessageBox.Cancel)
+            
+                if res == QtGui.QMessageBox.Cancel:
+                    return False
+                else:
+                    if not os.path.exists(os.path.dirname(file_path)):
+                        os.makedirs(os.path.dirname(file_path))
+                tde4.saveProject(file_path)
+            return True

--- a/hooks/tk-multi-workfiles2/scene_operation_tk-clarisse.py
+++ b/hooks/tk-multi-workfiles2/scene_operation_tk-clarisse.py
@@ -1,0 +1,170 @@
+# Copyright (c) 2013 Shotgun Software Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+import os
+import sys
+
+import ix
+
+import sgtk
+from sgtk.platform.qt import QtGui
+
+HookClass = sgtk.get_hook_baseclass()
+
+sys.path.append(os.path.dirname(__file__))
+import connect_databases
+
+__author__ = "Diego Garcia Huerta"
+__contact__ = "https://www.linkedin.com/in/diegogh/"
+
+
+class SceneOperation(HookClass):
+    """
+    Hook called to perform an operation with the
+    current scene
+    """
+
+    def set_content_directory(self, file_path):
+        """
+        Set Clarisse Project Content's directory preference $CDIR
+
+        :param file_path:       String
+                                The full path to the clarisse project
+        """
+        content_dir = os.path.join(os.path.dirname(file_path), "Content")
+        preferences = ix.application.get_prefs()
+        preferences.set_string_value(
+            "project", "content_directory", content_dir
+        )
+
+    def execute(
+        self,
+        operation,
+        file_path,
+        context,
+        parent_action,
+        file_version,
+        read_only,
+        **kwargs
+    ):
+        """
+        Main hook entry point
+
+        :param operation:       String
+                                Scene operation to perform
+
+        :param file_path:       String
+                                File path to use if the operation
+                                requires it (e.g. open)
+
+        :param context:         Context
+                                The context the file operation is being
+                                performed in.
+
+        :param parent_action:   This is the action that this scene operation is
+                                being executed for.  This can be one of:
+                                - open_file
+                                - new_file
+                                - save_file_as
+                                - version_up
+
+        :param file_version:    The version/revision of the file to be opened. 
+                                If this is 'None' then the latest version
+                                should be opened.
+
+        :param read_only:       Specifies if the file should be opened
+                                read-only or not
+
+        :returns:               Depends on operation:
+                                'current_path' - Return the current scene
+                                                file path as a String
+                                'reset'        - True if scene was reset to an 
+                                                empty state, otherwise False
+                                all others     - None
+        """
+        DB = connect_databases.Databases()
+        user_name    = context.user['name']
+        project_name = context.project['name']
+        shot_name    = context.entity['name']
+        tool         = 'Clarisse'
+        if file_path:
+            file_path = file_path.replace("/", os.path.sep)
+            file_name = os.path.basename(file_path)
+        else :
+            file_name    = shot_name
+        app = self.parent
+
+        app.log_debug("-" * 50)
+        app.log_debug("operation: %s" % operation)
+        app.log_debug("file_path: %s" % file_path)
+        app.log_debug("context: %s" % context)
+        app.log_debug("parent_action: %s" % parent_action)
+        app.log_debug("file_version: %s" % file_version)
+        app.log_debug("read_only: %s" % read_only)
+
+        if operation == "current_path":
+            # return the current scene path
+            return ix.application.get_current_project_filename()
+
+        elif operation == "open":
+            ix.application.disable()
+            ix.application.load_project(file_path)
+            self.set_content_directory(file_path)
+            ix.application.enable()
+            sql = DB.set_sql( user_name, tool, project_name, shot_name, file_name, 'OPEN' )
+            DB.insertDB(sql)
+
+        elif operation == "save":
+            file_path = ix.application.get_current_project_filename()
+            ix.application.save_project(file_path)
+            self.set_content_directory(file_path)
+            sql = DB.set_sql( user_name, tool, project_name, shot_name, file_name, 'SAVE' )
+            DB.insertDB(sql)
+
+        elif operation == "save_as":
+            res = QtGui.QMessageBox.question(None,
+                                                "Save as",
+                                                "Your scene has unsaved changes. Save before proceeding?",
+                                                QtGui.QMessageBox.Yes|QtGui.QMessageBox.No|QtGui.QMessageBox.Cancel)
+            ix.application.save_project(file_path)
+            self.set_content_directory(file_path)
+            sql = DB.set_sql( user_name, tool, project_name, shot_name, file_name, 'SAVE AS' )
+            DB.insertDB(sql)
+
+        elif operation == "prepare_new":
+            sql = DB.set_sql( user_name, tool, project_name, shot_name, file_name, 'NEW FILE' )
+            DB.insertDB(sql)
+
+        elif operation == "reset":
+            # Propose to save the project if it's modified
+            app.log_debug("checking if needing to save...")
+            reponse, file_path = ix.check_need_save()
+
+            if reponse.is_yes():
+                app.log_debug("saving filename: %s" % file_path)
+                ix.application.save_project(file_path)
+                self.set_content_directory(file_path)
+
+            if not reponse.is_cancelled():
+                # TODO set content directory
+                # Probably take the workfile template to figure out where to
+                # point it to.
+
+                app.log_debug("creating new project...")
+                # create an empty project
+                ix.application.new_project()
+                # clear and reset all Clarisse windows
+                ix.application.reset_windows_layout()
+                # load startup scene (define in Clarisse Preferences)
+                app.log_debug("loading startup scene...")
+                ix.application.load_startup_scene()
+            else:
+                return False
+            return True

--- a/hooks/tk-multi-workfiles2/scene_operation_tk-houdini.py
+++ b/hooks/tk-multi-workfiles2/scene_operation_tk-houdini.py
@@ -1,0 +1,87 @@
+# Copyright (c) 2013 Shotgun Software Inc.
+# 
+# CONFIDENTIAL AND PROPRIETARY
+# 
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit 
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your 
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights 
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+import os
+import hou
+
+import tank
+from tank import Hook
+from tank import TankError
+
+
+import sgtk
+from sgtk.platform.qt import QtGui
+
+class SceneOperation(Hook):
+    """
+    Hook called to perform an operation with the current scene
+    """
+    def execute(self, operation, file_path, context, parent_action, file_version, read_only, **kwargs):
+        """
+        Main hook entry point
+        
+        :param operation:       String
+                                Scene operation to perform
+        
+        :param file_path:       String
+                                File path to use if the operation
+                                requires it (e.g. open)
+                    
+        :param context:         Context
+                                The context the file operation is being
+                                performed in.
+                    
+        :param parent_action:   This is the action that this scene operation is
+                                being executed for.  This can be one of:
+                                - open_file
+                                - new_file
+                                - save_file_as 
+                                - version_up
+                        
+        :param file_version:    The version/revision of the file to be opened.  If this is 'None'
+                                then the latest version should be opened.
+        
+        :param read_only:       Specifies if the file should be opened read-only or not
+                            
+        :returns:               Depends on operation:
+                                'current_path' - Return the current scene
+                                                file path as a String
+                                'reset'        - True if scene was reset to an empty 
+                                                state, otherwise False
+                                all others     - None
+        """
+        
+        if operation == "current_path":
+            return str(hou.hipFile.name())
+        elif operation == "open":
+            # give houdini forward slashes
+            res = QtGui.QMessageBox.question(None,
+                                                "Open",
+                                                "Your scene has unsaved changes. Save before proceeding?",
+                                                QtGui.QMessageBox.Yes|QtGui.QMessageBox.No|QtGui.QMessageBox.Cancel)
+            file_path = file_path.replace(os.path.sep, '/')
+            hou.hipFile.load(file_path.encode("utf-8"))
+        elif operation == "save":
+            res = QtGui.QMessageBox.question(None,
+                                                "Save",
+                                                "Your scene has unsaved changes. Save before proceeding?",
+                                                QtGui.QMessageBox.Yes|QtGui.QMessageBox.No|QtGui.QMessageBox.Cancel)
+            hou.hipFile.save()
+        elif operation == "save_as":
+            # give houdini forward slashes
+            res = QtGui.QMessageBox.question(None,
+                                                "Save as",
+                                                "Your scene has unsaved changes. Save before proceeding?",
+                                                QtGui.QMessageBox.Yes|QtGui.QMessageBox.No|QtGui.QMessageBox.Cancel)
+            file_path = file_path.replace(os.path.sep, '/')
+            hou.hipFile.save(str(file_path.encode("utf-8")))
+        elif operation == "reset":
+            hou.hipFile.clear()
+            return True

--- a/hooks/tk-multi-workfiles2/scene_operation_tk-katana.py
+++ b/hooks/tk-multi-workfiles2/scene_operation_tk-katana.py
@@ -1,0 +1,112 @@
+# By Sam Saxon sam.saxon@thefoundry.com
+# Copied from the equivalent Nuke file.
+
+import os
+import sys
+from Katana import KatanaFile
+
+import sgtk
+from sgtk.platform.qt import QtGui
+
+HookClass = sgtk.get_hook_baseclass()
+
+sys.path.append(os.path.dirname(__file__))
+import connect_databases
+
+class SceneOperation(HookClass):
+    """
+    Hook called to perform an operation with the
+    current scene
+    """
+
+    def execute(self, operation, file_path, context, parent_action, file_version, read_only, **kwargs):
+        """
+        Main hook entry point
+
+        :param operation:       String
+                                Scene operation to perform
+
+        :param file_path:       String
+                                File path to use if the operation
+                                requires it (e.g. open)
+
+        :param context:         Context
+                                The context the file operation is being
+                                performed in.
+
+        :param parent_action:   This is the action that this scene operation is
+                                being executed for.  This can be one of:
+                                - open_file
+                                - new_file
+                                - save_file_as
+                                - version_up
+
+        :param file_version:    The version/revision of the file to be opened.  If this is 'None'
+                                then the latest version should be opened.
+
+        :param read_only:       Specifies if the file should be opened read-only or not
+
+        :returns:               Depends on operation:
+                                'current_path' - Return the current scene
+                                                file path as a String
+                                'reset'        - True if scene was reset to an empty
+                                                state, otherwise False
+                                all others     - None
+        """
+        DB = connect_databases.Databases()
+        user_name    = context.user['name']
+        project_name = context.project['name']
+        shot_name    = context.entity['name']
+        tool         = 'Katana'
+        if file_path:
+            file_path = file_path.replace("/", os.path.sep)
+            file_name = os.path.basename(file_path)
+        else :
+            file_name    = shot_name
+        if operation == "current_path":
+            # return the current scene path
+            return file_path
+
+        elif operation == "open":
+            KatanaFile.Load(file_path)
+            sql = DB.set_sql( user_name, tool, project_name, shot_name, file_name, 'OPEN' )
+            DB.insertDB(sql)
+
+        elif operation == "save":
+            if not os.path.exists(os.path.dirname(file_path)):
+                os.makedirs(os.path.dirname(file_path))
+            KatanaFile.Save(file_path)
+            sql = DB.set_sql( user_name, tool, project_name, shot_name, file_name, 'SAVE' )
+            DB.insertDB(sql)
+
+        elif operation == "save_as":
+            if not os.path.exists(os.path.dirname(file_path)):
+                os.makedirs(os.path.dirname(file_path))
+            KatanaFile.Save(file_path)
+            sql = DB.set_sql( user_name, tool, project_name, shot_name, file_name, 'SAVE AS' )
+            DB.insertDB(sql)
+            
+        elif operation == "prepare_new":
+            sql = DB.set_sql( user_name, tool, project_name, shot_name, file_name, 'NEW FILE' )
+            DB.insertDB(sql)
+
+
+        elif operation == "reset":
+
+            while KatanaFile.IsFileDirty():
+                # Changes have been made to the scene
+                res = QtGui.QMessageBox.question(None,
+                                                "Save your scene?",
+                                                "Your scene has unsaved changes. Save before proceeding?",
+                                                QtGui.QMessageBox.Yes|QtGui.QMessageBox.No|QtGui.QMessageBox.Cancel)
+            
+                if res == QtGui.QMessageBox.Cancel:
+                    return False
+                elif res == QtGui.QMessageBox.No:
+                    break
+                else:
+                    if not os.path.exists(os.path.dirname(file_path)):
+                        os.makedirs(os.path.dirname(file_path))
+                KatanaFile.Save(file_path) # TODO: warning: this may not work...
+            return True
+            

--- a/hooks/tk-multi-workfiles2/scene_operation_tk-maya.py
+++ b/hooks/tk-multi-workfiles2/scene_operation_tk-maya.py
@@ -1,0 +1,141 @@
+# Copyright (c) 2013 Shotgun Software Inc.
+# 
+# CONFIDENTIAL AND PROPRIETARY
+# 
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit 
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your 
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights 
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+import os
+import sys
+import maya.cmds as cmds
+
+import tank
+from tank import Hook
+from tank import TankError
+from tank.platform.qt import QtGui
+
+sys.path.append(os.path.dirname(__file__))
+import connect_databases
+
+class SceneOperation(Hook):
+    """
+    Hook called to perform an operation with the 
+    current scene
+    """
+    
+    def execute(self, operation, file_path, context, parent_action, file_version, read_only, **kwargs):
+        """
+        Main hook entry point
+        
+        :param operation:       String
+                                Scene operation to perform
+        
+        :param file_path:       String
+                                File path to use if the operation
+                                requires it (e.g. open)
+                    
+        :param context:         Context
+                                The context the file operation is being
+                                performed in.
+                    
+        :param parent_action:   This is the action that this scene operation is
+                                being executed for.  This can be one of:
+                                - open_file
+                                - new_file
+                                - save_file_as 
+                                - version_up
+                        
+        :param file_version:    The version/revision of the file to be opened.  If this is 'None'
+                                then the latest version should be opened.
+        
+        :param read_only:       Specifies if the file should be opened read-only or not
+                            
+        :returns:               Depends on operation:
+                                'current_path' - Return the current scene
+                                                file path as a String
+                                'reset'        - True if scene was reset to an empty 
+                                                state, otherwise False
+                                all others     - None
+        """
+        DB = connect_databases.Databases()
+        user_name    = context.user['name']
+        project_name = context.project['name']
+        shot_name    = context.entity['name']
+        tool         = 'Maya'
+        if file_path:
+            file_path = file_path.replace("/", os.path.sep)
+            file_name = os.path.basename(file_path)
+        else :
+            file_name    = shot_name
+        # cmds.warning(context)
+        if operation == "current_path":
+            # return the current scene path
+            return cmds.file(query=True, sceneName=True)
+
+        elif operation == "open":
+            # do new scene as Maya doesn't like opening 
+            # the scene it currently has open!   
+            cmds.file(new=True, force=True) 
+            cmds.file(file_path, open=True, force=True)
+            sql = DB.set_sql( user_name, tool, project_name, shot_name, file_name, 'OPEN' )
+            DB.insertDB(sql)
+
+        elif operation == "save":
+            # save the current scene:
+            cmds.file(save=True)
+            sql = DB.set_sql( user_name, tool, project_name, shot_name, file_name, 'SAVE' )
+            DB.insertDB(sql)
+
+        elif operation == "save_as":
+            # first rename the scene as file_path:
+            cmds.file(rename=file_path)
+            
+            # Maya can choose the wrong file type so
+            # we should set it here explicitely based
+            # on the extension
+            maya_file_type = None
+            if file_path.lower().endswith(".ma"):
+                maya_file_type = "mayaAscii"
+            elif file_path.lower().endswith(".mb"):
+                maya_file_type = "mayaBinary"
+            
+            # save the scene:
+            if maya_file_type:
+                cmds.file(save=True, force=True, type=maya_file_type)
+            else:
+                cmds.file(save=True, force=True)
+            sql = DB.set_sql( user_name, tool, project_name, shot_name, file_name, 'SAVE AS' )
+            DB.insertDB(sql)
+                
+        elif operation == "prepare_new":
+            sql = DB.set_sql( user_name, tool, project_name, shot_name, file_name, 'NEW FILE' )
+            DB.insertDB(sql)
+
+        elif operation == "reset":
+            """
+            Reset the scene to an empty state
+            """
+            while cmds.file(query=True, modified=True):
+                # changes have been made to the scene
+                res = QtGui.QMessageBox.question(None,
+                                                "Save your scene?",
+                                                "Your scene has unsaved changes. Save before proceeding?",
+                                                QtGui.QMessageBox.Yes|QtGui.QMessageBox.No|QtGui.QMessageBox.Cancel)
+            
+                if res == QtGui.QMessageBox.Cancel:
+                    return False
+                elif res == QtGui.QMessageBox.No:
+                    break
+                else:
+                    scene_name = cmds.file(query=True, sn=True)
+                    if not scene_name:
+                        cmds.SaveSceneAs()
+                    else:
+                        cmds.file(save=True)
+            
+            # do new file:    
+            cmds.file(newFile=True, force=True)
+            return True

--- a/hooks/tk-multi-workfiles2/scene_operation_tk-nuke.py
+++ b/hooks/tk-multi-workfiles2/scene_operation_tk-nuke.py
@@ -1,0 +1,250 @@
+# Copyright (c) 2013 Shotgun Software Inc.
+# 
+# CONFIDENTIAL AND PROPRIETARY
+# 
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit 
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your 
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights 
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+import os, sys
+import nuke
+
+import tank
+from tank import Hook
+from tank import TankError
+from tank.platform.qt import QtGui
+
+sys.path.append(os.path.dirname(__file__))
+import connect_databases
+
+class SceneOperation(Hook):
+    """
+    Hook called to perform an operation with the current scene.
+    """
+    def execute(self, *args, **kwargs):
+        """
+        Main hook entry point
+        
+        :param operation:       String
+                                Scene operation to perform
+        
+        :param file_path:       String
+                                File path to use if the operation
+                                requires it (e.g. open)
+                    
+        :param context:         Context
+                                The context the file operation is being
+                                performed in.
+                    
+        :param parent_action:   This is the action that this scene operation is
+                                being executed for.  This can be one of:
+                                - open_file
+                                - new_file
+                                - save_file_as 
+                                - version_up
+                        
+        :param file_version:    The version/revision of the file to be opened.  If this is 'None'
+                                then the latest version should be opened.
+        
+        :param read_only:       Specifies if the file should be opened read-only or not
+                            
+        :returns:               Depends on operation:
+                                'current_path' - Return the current scene
+                                                 file path as a String
+                                'reset'        - True if scene was reset to an empty 
+                                                 state, otherwise False
+                                all others     - None
+        """
+        engine = self.parent.engine
+        if hasattr(engine, "hiero_enabled") and engine.hiero_enabled:
+            return self._hiero_execute(*args, **kwargs)
+        elif hasattr(engine, "studio_enabled") and engine.studio_enabled:
+            return self._studio_execute(*args, **kwargs)
+        else:
+            return self._nuke_execute(*args, **kwargs)
+
+    def _studio_execute(self, operation, file_path, context, parent_action, file_version, read_only, **kwargs):
+        """
+        The Nuke Studio specific scene operations.
+        """
+        # Out of the box, we treat Nuke Studio just like Hiero, so we
+        # can just call through.
+        return self._hiero_execute(
+            operation,
+            file_path,
+            context,
+            parent_action,
+            file_version,
+            read_only,
+            **kwargs
+        )
+
+    def _hiero_execute(self, operation, file_path, context, parent_action, file_version, read_only, **kwargs):
+        """
+        The Hiero specific scene operations.
+        """
+        import hiero
+
+        if operation == "current_path":
+            # return the current script path
+            project = self._get_current_project()
+            curr_path = project.path().replace("/", os.path.sep)
+            return curr_path
+        elif operation == "open":
+            # Manually fire the kBeforeProjectLoad event in order to work around a bug in Hiero.
+            # The Foundry has logged this bug as:
+            #   Bug 40413 - Python API - kBeforeProjectLoad event type is not triggered 
+            #   when calling hiero.core.openProject() (only triggered through UI)
+            # It exists in all versions of Hiero through (at least) v1.9v1b12. 
+            #
+            # Once this bug is fixed, a version check will need to be added here in order to 
+            # prevent accidentally firing this event twice. The following commented-out code
+            # is just an example, and will need to be updated when the bug is fixed to catch the 
+            # correct versions.
+            # if (hiero.core.env['VersionMajor'] < 1 or 
+            #     hiero.core.env['VersionMajor'] == 1 and hiero.core.env['VersionMinor'] < 10:
+            hiero.core.events.sendEvent("kBeforeProjectLoad", None)
+
+            # open the specified script
+            hiero.core.openProject(file_path.replace(os.path.sep, "/"))
+        elif operation == "save":
+            # save the current script:
+            project = self._get_current_project()
+            project.save()
+        elif operation == "save_as":
+            project = self._get_current_project()
+            project.saveAs(file_path.replace(os.path.sep, "/"))
+        elif operation == "reset":
+            # do nothing and indicate scene was reset to empty
+            return True
+        elif operation == "prepare_new":
+            # add a new project to hiero
+            hiero.core.newProject()
+    
+    def _nuke_execute(self, operation, file_path, context, parent_action, file_version, read_only, **kwargs):
+        """
+        The Nuke specific scene operations.
+        """
+        DB = connect_databases.Databases()
+        user_name    = context.user['name']
+        project_name = context.project['name']
+        shot_name    = context.entity['name']
+        tool         = 'Nuke'
+        if file_path:
+            file_path = file_path.replace("/", os.path.sep)
+            file_name = os.path.basename(file_path)
+        else :
+            file_name = shot_name
+
+        if operation == "current_path":
+            # return the current script path
+            return nuke.root().name().replace("/", os.path.sep)
+
+        elif operation == "open":
+            # open the specified script
+            nuke.scriptOpen(file_path)
+            sql = DB.set_sql( user_name, tool, project_name, shot_name, file_name, 'OPEN' )
+            DB.insertDB(sql)
+
+            # reset any write node render paths:
+            if self._reset_write_node_render_paths():
+                # something changed so make sure to save the script again:
+                nuke.scriptSave()
+
+        elif operation == "save":
+            # save the current script:
+            #nuke.alert('save')
+            nuke.scriptSave()
+            sql = DB.set_sql( user_name, tool, project_name, shot_name, file_name, 'SAVE' )
+            DB.insertDB(sql)
+
+        elif operation == "save_as":
+            old_path = nuke.root()["name"].value()
+            try:
+                # rename script:
+                nuke.root()["name"].setValue(file_path)
+                
+                # reset all write nodes:
+                self._reset_write_node_render_paths()
+                        
+                # save script:
+                nuke.scriptSaveAs(file_path, -1)
+                sql = DB.set_sql( user_name, tool, project_name, shot_name, file_name, 'SAVE AS' )
+                DB.insertDB(sql)    
+            except Exception as e:
+                # something went wrong so reset to old path:
+                nuke.root()["name"].setValue(old_path)
+                raise TankError("Failed to save scene %s", e)
+
+        elif operation == "prepare_new":
+            sql = DB.set_sql( user_name, tool, project_name, shot_name, file_name, 'NEW FILE' )
+            DB.insertDB(sql)
+
+
+        elif operation == "reset":
+            """
+            Reset the scene to an empty state
+            """
+            while nuke.root().modified():
+                # changes have been made to the scene
+                res = QtGui.QMessageBox.question(None,
+                                                "Save your script?",
+                                                "Your script has unsaved changes. Save before proceeding?",
+                                                QtGui.QMessageBox.Yes|QtGui.QMessageBox.No|QtGui.QMessageBox.Cancel)
+            
+                if res == QtGui.QMessageBox.Cancel:
+                    return False
+                elif res == QtGui.QMessageBox.No:
+                    break
+                else:
+                    nuke.scriptSave()
+
+            # now clear the script:
+            nuke.scriptClear()
+            return True
+
+    def _get_current_project(self):
+        """
+        Returns the current project based on where in the UI the user clicked 
+        """
+        import hiero
+        # get the menu selection from hiero engine
+        selection = self.parent.engine.get_menu_selection()
+
+        if len(selection) != 1:
+            raise TankError("Please select a single Project!")
+        
+        if not isinstance(selection[0] , hiero.core.Bin):
+            raise TankError("Please select a Hiero Project!")
+            
+        project = selection[0].project()
+        if project is None:
+            # apparently bins can be without projects (child bins I think)
+            raise TankError("Please select a Hiero Project!")
+
+        return project
+        
+    def _reset_write_node_render_paths(self):
+        """
+        Use the tk-nuke-writenode app interface to find and reset
+        the render path of any Tank write nodes in the current script
+        """
+        write_node_app = self.parent.engine.apps.get("tk-nuke-writenode")
+        if not write_node_app:
+            return False
+
+        # only need to forceably reset the write node render paths if the app version
+        # is less than or equal to v0.1.11
+        from distutils.version import LooseVersion
+        if (write_node_app.version == "Undefined" 
+            or LooseVersion(write_node_app.version) > LooseVersion("v0.1.11")):
+            return False
+        
+        write_nodes = write_node_app.get_write_nodes()
+        for write_node in write_nodes:
+            write_node_app.reset_node_render_path(write_node)
+            
+        return len(write_nodes) > 0      
+        

--- a/hooks/tk-multi-workfiles2/scene_operation_tk-photoshop.py
+++ b/hooks/tk-multi-workfiles2/scene_operation_tk-photoshop.py
@@ -1,0 +1,115 @@
+# Copyright (c) 2013 Shotgun Software Inc.
+# 
+# CONFIDENTIAL AND PROPRIETARY
+# 
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit 
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your 
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights 
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+import os
+import sys
+import photoshop
+
+from tank import Hook
+from tank import TankError
+from sgtk.platform.qt import QtGui
+
+class SceneOperation(Hook):
+    """
+    Hook called to perform an operation with the
+    current scene
+    """
+    
+    def execute(self, operation, file_path, context, parent_action, file_version, read_only, **kwargs):
+        """
+        Main hook entry point
+        
+        :param operation:       String
+                                Scene operation to perform
+        
+        :param file_path:       String
+                                File path to use if the operation
+                                requires it (e.g. open)
+                    
+        :param context:         Context
+                                The context the file operation is being
+                                performed in.
+                    
+        :param parent_action:   This is the action that this scene operation is
+                                being executed for.  This can be one of:
+                                - open_file
+                                - new_file
+                                - save_file_as 
+                                - version_up
+                        
+        :param file_version:    The version/revision of the file to be opened.  If this is 'None'
+                                then the latest version should be opened.
+        
+        :param read_only:       Specifies if the file should be opened read-only or not
+                            
+        :returns:               Depends on operation:
+                                'current_path' - Return the current scene
+                                                file path as a String
+                                'reset'        - True if scene was reset to an empty 
+                                                state, otherwise False
+                                all others     - None
+        """
+
+        if operation == "current_path":
+            # return the current script path
+            doc = self._get_active_document()
+
+            if doc.fullName is None:
+                # new file?
+                path = ""
+            else:
+                path = doc.fullName.nativePath
+            
+            return path
+
+        elif operation == "open":
+            res = QtGui.QMessageBox.question(None,
+                                                "!! Open !!",
+                                                "Your scene has unsaved changes. Save before proceeding?",
+                                                QtGui.QMessageBox.Yes|QtGui.QMessageBox.No|QtGui.QMessageBox.Cancel)
+            # open the specified script
+            f = photoshop.RemoteObject('flash.filesystem::File', file_path)
+            photoshop.app.load(f)            
+        
+        elif operation == "save":
+            res = QtGui.QMessageBox.question(None,
+                                                "!! Save !!",
+                                                "Your scene has unsaved changes. Save before proceeding?",
+                                                QtGui.QMessageBox.Yes|QtGui.QMessageBox.No|QtGui.QMessageBox.Cancel)
+            # save the current script:
+            doc = self._get_active_document()
+            doc.save()
+        
+        elif operation == "save_as":
+            res = QtGui.QMessageBox.question(None,
+                                                "!! Save as !!",
+                                                "Your scene has unsaved changes. Save before proceeding?",
+                                                QtGui.QMessageBox.Yes|QtGui.QMessageBox.No|QtGui.QMessageBox.Cancel)
+            doc = self._get_active_document()
+            photoshop.save_as(doc, file_path)
+
+        elif operation == "reset":
+            # do nothing and indicate scene was reset to empty
+            return True
+        
+        elif operation == "prepare_new":
+            # file->new. Not sure how to pop up the actual file->new UI,
+            # this command will create a document with default properties
+            photoshop.app.documents.add()
+        
+    def _get_active_document(self):
+        """
+        Returns the currently open document in Photoshop.
+        Raises an exeption if no document is active.
+        """
+        doc = photoshop.app.activeDocument
+        if doc is None:
+            raise TankError("There is no currently active document!")
+        return doc


### PR DESCRIPTION
리눅스 환경에서 workfiles2 실행 로그 생성
- 적용된 dcc 툴 : maya, nuke, houdini, katana, clarisse, 3de4
- scene_operation_tool 위치 통일
- 툴 실행 후 entity 없을 때의 workfiles2 hook 위치 수정