### PR TITLE
update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@ core/pipeline_configuration.yml
 
 */install_location.yml
 */pipeline_configuration.yml
+
+# temp ignore list
+env/includes/
+


### PR DESCRIPTION
툴킷 버젼이 업데이트 되지 않는 상태에서 merge하게 되면 생기는 오류 방지를 위한 임시 gitignore